### PR TITLE
Add context, dependency base and proyect class

### DIFF
--- a/lib/code_sheriff.rb
+++ b/lib/code_sheriff.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require 'code_sheriff/version'
+require 'code_sheriff/context'
+require 'code_sheriff/project'
+require 'code_sheriff/dependencies/base'
 
 module CodeSheriff
-  class Error < StandardError; end
-  # Your code goes here...
 end

--- a/lib/code_sheriff/context.rb
+++ b/lib/code_sheriff/context.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CodeSheriff
+  class Context
+    def gemfile_path
+      "#{folder_path}/Gemfile"
+    end
+
+    def folder_path
+      `pwd`.sub("\n", '')
+    end
+  end
+end

--- a/lib/code_sheriff/dependencies/base.rb
+++ b/lib/code_sheriff/dependencies/base.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module CodeSheriff
+  module Dependencies
+    class Base
+      attr_reader :config_file_destination, :config_file_source, :name, :version
+
+      def initialize(config_file_source: nil, config_file_destination: nil, name:,
+                     version: nil)
+        @config_file_source = config_file_source
+        @config_file_destination = config_file_destination
+        @name = name
+        @version = version ? "'#{version}'" : nil
+      end
+
+      def add_config_file(context)
+        if config_file_source
+          File.open("#{context.folder_path}/#{config_file_destination}", 'w') do |file|
+            file.puts config_file_source_content
+          end
+        end
+
+        puts "\t#{name.capitalize} installed"
+      end
+
+      def gemfile_code
+        "gem '#{name}', group: :development"
+      end
+
+      def gemspec_code
+        "  spec.add_development_dependency '#{name}'"
+      end
+
+      private
+
+      def config_file_source_content
+        File.read(config_file_source)
+      end
+    end
+  end
+end

--- a/lib/code_sheriff/project.rb
+++ b/lib/code_sheriff/project.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CodeSheriff
+  class Project
+    def create
+      CodeSheriff::Context.new
+    end
+  end
+end


### PR DESCRIPTION
This PR adds:
- A `Base` dependency class from which to create the Dependencies
- `Context` class with functions that return the paths to the files that will be modified relative to the project in which the gem is being executed
- `Project` class that represents the ruby project (either ruby gem or RoR project) 